### PR TITLE
Add the ability to change the 'workspace' location

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,6 @@ module.exports = {
     'import/no-unresolved': 'error',
     // Since React 17 and typescript 4.1 you can safely disable the rule
     'react/react-in-jsx-scope': 'off',
-    'no-underscore-dangle': ['error', { allowAfterThis: true }],
   },
   parserOptions: {
     ecmaVersion: 2020,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     'import/no-unresolved': 'error',
     // Since React 17 and typescript 4.1 you can safely disable the rule
     'react/react-in-jsx-scope': 'off',
+    'no-underscore-dangle': ['error', { allowAfterThis: true }],
   },
   parserOptions: {
     ecmaVersion: 2020,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dompurify": "^2.4.1",
         "electron-debug": "^3.2.0",
         "electron-log": "^4.4.8",
+        "electron-store": "^8.1.0",
         "electron-updater": "^5.2.3",
         "furigana-markdown-it": "^1.0.3",
         "highlight.js": "^11.7.0",
@@ -5176,7 +5177,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -5193,7 +5193,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -5208,8 +5207,7 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -5615,6 +5613,14 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/axe-core": {
@@ -6886,6 +6892,63 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/conf": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
+      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
+      "dependencies": {
+        "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.1",
+        "atomically": "^1.7.0",
+        "debounce-fn": "^4.0.0",
+        "dot-prop": "^6.0.1",
+        "env-paths": "^2.2.1",
+        "json-schema-typed": "^7.0.3",
+        "onetime": "^5.1.2",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/conf/node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -7489,6 +7552,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/debounce-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "dependencies": {
+        "mimic-fn": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debounce-fn/node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/debug": {
@@ -8577,6 +8662,29 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/electron-store": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.1.0.tgz",
+      "integrity": "sha512-2clHg/juMjOH0GT9cQ6qtmIvK183B39ZXR0bUoPwKwYHJsEF3quqyDzMFUAu+0OP8ijmN2CbPRAelhNbWUbzwA==",
+      "dependencies": {
+        "conf": "^10.2.0",
+        "type-fest": "^2.17.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-store/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.222",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.222.tgz",
@@ -8770,7 +8878,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10280,8 +10387,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
@@ -11841,7 +11947,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -13197,6 +13302,11 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/json-schema-typed": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -14171,7 +14281,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -14782,7 +14891,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -14939,7 +15047,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -15199,6 +15306,73 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-up/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/plist": {
@@ -15925,7 +16099,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -16417,7 +16590,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18398,7 +18570,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -23062,7 +23233,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "requires": {
         "ajv": "^8.0.0"
       },
@@ -23071,7 +23241,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -23082,8 +23251,7 @@
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },
@@ -23401,6 +23569,11 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
+    },
+    "atomically": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="
     },
     "axe-core": {
       "version": "4.4.3",
@@ -24387,6 +24560,49 @@
         }
       }
     },
+    "conf": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
+      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
+      "requires": {
+        "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.1",
+        "atomically": "^1.7.0",
+        "debounce-fn": "^4.0.0",
+        "dot-prop": "^6.0.1",
+        "env-paths": "^2.2.1",
+        "json-schema-typed": "^7.0.3",
+        "onetime": "^5.1.2",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "dot-prop": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+          "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
     "config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -24822,6 +25038,21 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
       "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
       "dev": true
+    },
+    "debounce-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "requires": {
+        "mimic-fn": "^3.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
+        }
+      }
     },
     "debug": {
       "version": "4.3.4",
@@ -25677,6 +25908,22 @@
         }
       }
     },
+    "electron-store": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.1.0.tgz",
+      "integrity": "sha512-2clHg/juMjOH0GT9cQ6qtmIvK183B39ZXR0bUoPwKwYHJsEF3quqyDzMFUAu+0OP8ijmN2CbPRAelhNbWUbzwA==",
+      "requires": {
+        "conf": "^10.2.0",
+        "type-fest": "^2.17.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.222",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.222.tgz",
@@ -25828,8 +26075,7 @@
     "env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "envinfo": {
       "version": "7.8.1",
@@ -26916,8 +27162,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -28070,8 +28315,7 @@
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
     "is-path-inside": {
       "version": "3.0.3",
@@ -29113,6 +29357,11 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-schema-typed": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -29837,8 +30086,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -30294,7 +30542,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -30401,8 +30648,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-json": {
       "version": "6.5.0",
@@ -30596,6 +30842,54 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
+        }
+      }
+    },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
         }
       }
     },
@@ -31086,8 +31380,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -31456,8 +31749,7 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "requires-port": {
       "version": "1.0.0",
@@ -32947,7 +33239,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "dompurify": "^2.4.1",
     "electron-debug": "^3.2.0",
     "electron-log": "^4.4.8",
+    "electron-store": "^8.1.0",
     "electron-updater": "^5.2.3",
     "furigana-markdown-it": "^1.0.3",
     "highlight.js": "^11.7.0",

--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -60,7 +60,7 @@ async function writeFile(file: string, content: string, encoding: BufferEncoding
  * @returns list of folder names.
  */
 export async function listFolders(): Promise<string[]> {
-  const files = await listFiles(applicationState.rootDirectory);
+  const files = await listFiles(applicationState.workspace);
   return files.filter((file) => isDirectory(file) && !isHidden(file)).map((file) => path.basename(file));
 }
 
@@ -70,7 +70,7 @@ export async function listFolders(): Promise<string[]> {
  * @returns list of note names.
  */
 export async function listNotes(folder: string): Promise<string[]> {
-  const files = await listFiles(path.join(applicationState.rootDirectory, folder));
+  const files = await listFiles(path.join(applicationState.workspace, folder));
   return files.filter((file) => isMarkdown(file) && !isHidden(file)).map((file) => path.basename(file, '.md'));
 }
 
@@ -81,7 +81,7 @@ export async function listNotes(folder: string): Promise<string[]> {
  * @returns contents of the note.
  */
 export async function fetchNote(folder: string, file: string): Promise<string> {
-  return readFile(path.join(applicationState.rootDirectory, folder, `${file}.md`), 'utf-8');
+  return readFile(path.join(applicationState.workspace, folder, `${file}.md`), 'utf-8');
 }
 
 /**
@@ -91,5 +91,5 @@ export async function fetchNote(folder: string, file: string): Promise<string> {
  * @param content contents of the note.
  */
 export async function saveNote(folder: string, file: string, content: string): Promise<void> {
-  return writeFile(path.join(applicationState.rootDirectory, folder, `${file}.md`), content, 'utf-8');
+  return writeFile(path.join(applicationState.workspace, folder, `${file}.md`), content, 'utf-8');
 }

--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-
-const root = path.join(process.env.HOME!, 'Notes');
+import applicationState from './state';
 
 function isDirectory(p: string): boolean {
   return fs.lstatSync(p).isDirectory();
@@ -61,7 +60,7 @@ async function writeFile(file: string, content: string, encoding: BufferEncoding
  * @returns list of folder names.
  */
 export async function listFolders(): Promise<string[]> {
-  const files = await listFiles(root);
+  const files = await listFiles(applicationState.rootDirectory);
   return files.filter((file) => isDirectory(file) && !isHidden(file)).map((file) => path.basename(file));
 }
 
@@ -71,7 +70,7 @@ export async function listFolders(): Promise<string[]> {
  * @returns list of note names.
  */
 export async function listNotes(folder: string): Promise<string[]> {
-  const files = await listFiles(path.join(root, folder));
+  const files = await listFiles(path.join(applicationState.rootDirectory, folder));
   return files.filter((file) => isMarkdown(file) && !isHidden(file)).map((file) => path.basename(file, '.md'));
 }
 
@@ -82,7 +81,7 @@ export async function listNotes(folder: string): Promise<string[]> {
  * @returns contents of the note.
  */
 export async function fetchNote(folder: string, file: string): Promise<string> {
-  return readFile(path.join(root, folder, `${file}.md`), 'utf-8');
+  return readFile(path.join(applicationState.rootDirectory, folder, `${file}.md`), 'utf-8');
 }
 
 /**
@@ -92,5 +91,5 @@ export async function fetchNote(folder: string, file: string): Promise<string> {
  * @param content contents of the note.
  */
 export async function saveNote(folder: string, file: string, content: string): Promise<void> {
-  return writeFile(path.join(root, folder, `${file}.md`), content, 'utf-8');
+  return writeFile(path.join(applicationState.rootDirectory, folder, `${file}.md`), content, 'utf-8');
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -54,7 +54,7 @@ const installExtensions = async () => {
       extensions.map((name) => installer[name]),
       forceDownload
     )
-    .catch(console.log);
+    .catch(log.error);
 };
 
 const createWindow = async () => {
@@ -138,4 +138,4 @@ app
       if (mainWindow === null) createWindow();
     });
   })
-  .catch(console.log);
+  .catch(log.error);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -27,7 +27,7 @@ class AppUpdater {
 
 let mainWindow: BrowserWindow | null = null;
 
-ipcMain.handle('root-directory', () => applicationState.rootDirectory);
+ipcMain.handle('get-workspace', () => applicationState.workspace);
 ipcMain.handle('list-folders', listFolders);
 ipcMain.handle('list-notes', (_, folder) => listNotes(folder));
 ipcMain.handle('fetch-note', (_, folder, note) => fetchNote(folder, note));

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import { autoUpdater } from 'electron-updater';
 import path from 'path';
 import { fetchNote, listFolders, listNotes, saveNote } from './files';
 import MenuBuilder from './menu';
+import applicationState from './state';
 import { resolveHtmlPath } from './util';
 
 class AppUpdater {
@@ -26,6 +27,7 @@ class AppUpdater {
 
 let mainWindow: BrowserWindow | null = null;
 
+ipcMain.handle('root-directory', () => applicationState.rootDirectory);
 ipcMain.handle('list-folders', listFolders);
 ipcMain.handle('list-notes', (_, folder) => listNotes(folder));
 ipcMain.handle('fetch-note', (_, folder, note) => fetchNote(folder, note));

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -77,9 +77,9 @@ export default class MenuBuilder {
       label: 'File',
       submenu: [
         {
-          label: 'Open',
+          label: 'Open Workspace...',
           accelerator: 'Command+O',
-          click: () => this.doFileOpen(),
+          click: () => this.doOpenWorkspace(),
         },
       ],
     };
@@ -192,9 +192,9 @@ export default class MenuBuilder {
         label: '&File',
         submenu: [
           {
-            label: '&Open',
+            label: '&Open Workspace...',
             accelerator: 'Ctrl+O',
-            onclick: () => this.doFileOpen(),
+            onclick: () => this.doOpenWorkspace(),
           },
           {
             label: '&Close',
@@ -276,12 +276,12 @@ export default class MenuBuilder {
     return templateDefault;
   }
 
-  private async doFileOpen() {
+  private async doOpenWorkspace() {
     const { filePaths, canceled } = await dialog.showOpenDialog({ properties: ['openDirectory'] });
     if (!canceled && filePaths.length > 0) {
       const [filePath] = filePaths;
-      applicationState.rootDirectory = filePath;
-      this.mainWindow.webContents.send('switched-root-directory', filePath);
+      applicationState.workspace = filePath;
+      this.mainWindow.webContents.send('switched-workspace', filePath);
     }
   }
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,4 +1,5 @@
-import { app, BrowserWindow, Menu, MenuItemConstructorOptions, shell } from 'electron';
+import { app, BrowserWindow, dialog, Menu, MenuItemConstructorOptions, shell } from 'electron';
+import applicationState from './state';
 
 interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
   selector?: string;
@@ -69,6 +70,16 @@ export default class MenuBuilder {
           click: () => {
             app.quit();
           },
+        },
+      ],
+    };
+    const subMenuFile: DarwinMenuItemConstructorOptions = {
+      label: 'File',
+      submenu: [
+        {
+          label: 'Open',
+          accelerator: 'Command+O',
+          click: () => this.doFileOpen(),
         },
       ],
     };
@@ -172,7 +183,7 @@ export default class MenuBuilder {
     const subMenuView =
       process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true' ? subMenuViewDev : subMenuViewProd;
 
-    return [subMenuAbout, subMenuEdit, subMenuView, subMenuWindow, subMenuHelp];
+    return [subMenuAbout, subMenuFile, subMenuEdit, subMenuView, subMenuWindow, subMenuHelp];
   }
 
   buildDefaultTemplate() {
@@ -183,6 +194,7 @@ export default class MenuBuilder {
           {
             label: '&Open',
             accelerator: 'Ctrl+O',
+            onclick: () => this.doFileOpen(),
           },
           {
             label: '&Close',
@@ -262,5 +274,14 @@ export default class MenuBuilder {
     ];
 
     return templateDefault;
+  }
+
+  private async doFileOpen() {
+    const { filePaths, canceled } = await dialog.showOpenDialog({ properties: ['openDirectory'] });
+    if (!canceled && filePaths.length > 0) {
+      const [filePath] = filePaths;
+      applicationState.rootDirectory = filePath;
+      this.mainWindow.webContents.send('switched-root-directory', filePath);
+    }
   }
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,8 +1,9 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
-export type Channels = 'list-folders' | 'list-notes';
+export type Channels = 'list-folders' | 'list-notes' | 'switched-root-directory';
 
 contextBridge.exposeInMainWorld('electron', {
+  rootDirectory: () => ipcRenderer.invoke('root-directory') as Promise<string>,
   listFolders: () => ipcRenderer.invoke('list-folders') as Promise<string[]>,
   listNotes: (folder: string) => ipcRenderer.invoke('list-notes', folder) as Promise<string[]>,
   fetchNote: (folder: string, note: string) => ipcRenderer.invoke('fetch-note', folder, note) as Promise<string>,

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,9 +1,9 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
-export type Channels = 'list-folders' | 'list-notes' | 'switched-root-directory';
+export type Channels = 'list-folders' | 'list-notes' | 'switched-workspace';
 
 contextBridge.exposeInMainWorld('electron', {
-  rootDirectory: () => ipcRenderer.invoke('root-directory') as Promise<string>,
+  getWorkspace: () => ipcRenderer.invoke('get-workspace') as Promise<string>,
   listFolders: () => ipcRenderer.invoke('list-folders') as Promise<string[]>,
   listNotes: (folder: string) => ipcRenderer.invoke('list-notes', folder) as Promise<string[]>,
   fetchNote: (folder: string, note: string) => ipcRenderer.invoke('fetch-note', folder, note) as Promise<string>,

--- a/src/main/state.ts
+++ b/src/main/state.ts
@@ -1,7 +1,10 @@
 import path from 'path';
 
 class State {
-  private _rootDirectory: string = path.join(process.env.HOME!, 'Notes');
+  private _rootDirectory: string = path.join(
+    process.env.HOME!,
+    process.env.NODE_ENV === 'production' ? 'Notes' : 'Notes (Testing)'
+  );
 
   get rootDirectory(): string {
     return this._rootDirectory;

--- a/src/main/state.ts
+++ b/src/main/state.ts
@@ -1,17 +1,32 @@
+import Store from 'electron-store';
+import os from 'os';
 import path from 'path';
 
-class State {
-  private _rootDirectory: string = path.join(
-    process.env.HOME!,
-    process.env.NODE_ENV === 'production' ? 'Notes' : 'Notes (Testing)'
-  );
+// Keys
+const CURRENT_WORKSPACE = 'currentWorkspace';
 
-  get rootDirectory(): string {
-    return this._rootDirectory;
+const initialWorkspace =
+  process.env.NODE_ENV === 'production'
+    ? path.join(os.homedir(), 'Notes')
+    : path.join(os.homedir(), 'Developer', 'Notes');
+
+class State {
+  private currentWorkspace: string;
+
+  private store: Store;
+
+  constructor() {
+    this.store = new Store();
+    this.currentWorkspace = (this.store.get(CURRENT_WORKSPACE) as string) ?? initialWorkspace;
   }
 
-  set rootDirectory(rootDirectory: string) {
-    this._rootDirectory = rootDirectory;
+  get workspace(): string {
+    return this.currentWorkspace;
+  }
+
+  set workspace(workspace: string) {
+    this.store.set(CURRENT_WORKSPACE, workspace);
+    this.currentWorkspace = workspace;
   }
 }
 

--- a/src/main/state.ts
+++ b/src/main/state.ts
@@ -1,0 +1,17 @@
+import path from 'path';
+
+class State {
+  private _rootDirectory: string = path.join(process.env.HOME!, 'Notes');
+
+  get rootDirectory(): string {
+    return this._rootDirectory;
+  }
+
+  set rootDirectory(rootDirectory: string) {
+    this._rootDirectory = rootDirectory;
+  }
+}
+
+const state = new State();
+
+export default state;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable no-console */
 import { Box } from '@mui/material';
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { MemoryRouter as Router, Route, Routes } from 'react-router-dom';
 import './App.css';
 import NotePane from './components/notepane/NotePane';
@@ -9,11 +10,25 @@ import { NoteKey } from './model';
 const drawerWidth = 240;
 
 const MainView = () => {
-  const [selected, setSelected] = React.useState<NoteKey | undefined>(undefined);
+  const [location, setLocation] = useState<string | undefined>(undefined);
+  const [selected, setSelected] = useState<NoteKey | undefined>(undefined);
+
+  useEffect(() => {
+    window.electron
+      .rootDirectory()
+      .then((newLocation) => {
+        return setLocation(newLocation as string);
+      })
+      .catch(console.log);
+    return window.electron.ipcRenderer.on('switched-root-directory', (newLocation) => {
+      setSelected(undefined);
+      setLocation(newLocation as string);
+    });
+  }, []);
 
   return (
     <Box sx={{ display: 'flex' }}>
-      <Sidebar width={drawerWidth} selected={selected} onSelect={setSelected} />
+      <Sidebar width={drawerWidth} location={location} selected={selected} onSelect={setSelected} />
       <NotePane width={`calc(100% - ${drawerWidth}px)`} note={selected} />
     </Box>
   );

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,25 +10,20 @@ import { NoteKey } from './model';
 const drawerWidth = 240;
 
 const MainView = () => {
-  const [location, setLocation] = useState<string | undefined>(undefined);
+  const [workspace, setWorkspace] = useState<string | undefined>(undefined);
   const [selected, setSelected] = useState<NoteKey | undefined>(undefined);
 
   useEffect(() => {
-    window.electron
-      .rootDirectory()
-      .then((newLocation) => {
-        return setLocation(newLocation as string);
-      })
-      .catch(console.log);
-    return window.electron.ipcRenderer.on('switched-root-directory', (newLocation) => {
+    window.electron.getWorkspace().then(setWorkspace).catch(console.log);
+    return window.electron.ipcRenderer.on('switched-workspace', (newWorkspace) => {
       setSelected(undefined);
-      setLocation(newLocation as string);
+      setWorkspace(newWorkspace as string);
     });
   }, []);
 
   return (
     <Box sx={{ display: 'flex' }}>
-      <Sidebar width={drawerWidth} location={location} selected={selected} onSelect={setSelected} />
+      <Sidebar width={drawerWidth} workspace={workspace} selected={selected} onSelect={setSelected} />
       <NotePane width={`calc(100% - ${drawerWidth}px)`} note={selected} />
     </Box>
   );

--- a/src/renderer/components/sidebar/Sidebar.tsx
+++ b/src/renderer/components/sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
 /* eslint no-console: off */
 import { Box, Drawer, List, ListSubheader } from '@mui/material';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { NoteKey } from '../../model';
 import { draggable, notDraggable } from '../../util/draggable';
 import SideBarFolder from './SidebarFolder';
@@ -8,6 +8,7 @@ import SideBarFolder from './SidebarFolder';
 interface Props {
   /** Width of the sidebar, in pixels */
   width: number;
+  location: string | undefined;
   selected: NoteKey | undefined;
   onSelect: (note: NoteKey) => void;
 }
@@ -15,7 +16,7 @@ interface Props {
 /**
  * Sidebar displaying a list of collapsible folders with their files.
  */
-const Sidebar = ({ width, selected, onSelect }: Props) => {
+const Sidebar = ({ width, location, selected, onSelect }: Props) => {
   const [folders, setFolders] = React.useState<string[] | undefined>(undefined);
   const [open, setOpen] = React.useState<string | undefined>(undefined);
   const [files, dispatch] = React.useReducer(
@@ -27,15 +28,19 @@ const Sidebar = ({ width, selected, onSelect }: Props) => {
     {}
   );
 
-  if (folders === undefined) {
+  useEffect(() => {
+    setFolders([]);
     window.electron.listFolders().then(setFolders).catch(console.log);
-  }
-  if (open !== undefined && !(open in files)) {
-    window.electron
-      .listNotes(open)
-      .then((f) => dispatch({ folder: open, files: f }))
-      .catch(console.log);
-  }
+  }, [location]);
+
+  useEffect(() => {
+    if (open && !(open in files)) {
+      window.electron
+        .listNotes(open)
+        .then((f) => dispatch({ folder: open, files: f }))
+        .catch(console.log);
+    }
+  }, [files, open]);
 
   const handleFolderClick = (folder: string) => {
     setOpen(open !== folder ? folder : undefined);

--- a/src/renderer/components/sidebar/Sidebar.tsx
+++ b/src/renderer/components/sidebar/Sidebar.tsx
@@ -8,7 +8,7 @@ import SideBarFolder from './SidebarFolder';
 interface Props {
   /** Width of the sidebar, in pixels */
   width: number;
-  location: string | undefined;
+  workspace: string | undefined;
   selected: NoteKey | undefined;
   onSelect: (note: NoteKey) => void;
 }
@@ -16,7 +16,7 @@ interface Props {
 /**
  * Sidebar displaying a list of collapsible folders with their files.
  */
-const Sidebar = ({ width, location, selected, onSelect }: Props) => {
+const Sidebar = ({ width, workspace, selected, onSelect }: Props) => {
   const [folders, setFolders] = React.useState<string[] | undefined>(undefined);
   const [open, setOpen] = React.useState<string | undefined>(undefined);
   const [files, dispatch] = React.useReducer(
@@ -31,7 +31,7 @@ const Sidebar = ({ width, location, selected, onSelect }: Props) => {
   useEffect(() => {
     setFolders([]);
     window.electron.listFolders().then(setFolders).catch(console.log);
-  }, [location]);
+  }, [workspace]);
 
   useEffect(() => {
     if (open && !(open in files)) {

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -3,7 +3,7 @@ import { Channels } from 'main/preload';
 declare global {
   interface Window {
     electron: {
-      rootDirectory: () => Promise<string>;
+      getWorkspace: () => Promise<string>;
       listFolders: () => Promise<string[]>;
       listNotes: (folder: string) => Promise<string[]>;
       fetchNote: (folder: string, note: string) => Promise<string>;

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -3,6 +3,7 @@ import { Channels } from 'main/preload';
 declare global {
   interface Window {
     electron: {
+      rootDirectory: () => Promise<string>;
       listFolders: () => Promise<string[]>;
       listNotes: (folder: string) => Promise<string[]>;
       fetchNote: (folder: string, note: string) => Promise<string>;


### PR DESCRIPTION
Adds a *File > Open Workspace...* menu item, allowing the user to switch between multiple sets of notes in different locations.

The default location for production builds is `${HOME}/Notes`, while development builds default to `${HOME}/Developer/Notes`.

The current workspace is resisted in on-disk and restored when re-opening the application.